### PR TITLE
add and use `bevy_crossbeam_event`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy-gotrue",
+ "bevy_crossbeam_event",
  "bevy_http_client",
  "crossbeam",
  "native-tls",
@@ -523,7 +524,8 @@ dependencies = [
 [[package]]
 name = "bevy_cosmic_edit"
 version = "0.20.0"
-source = "git+https://github.com/StaffEngineer/bevy_cosmic_edit#97517dccbd8d08aaeb043a0e87b95f3fbecdc545"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d310c7992a62cf4896b2ee5edbb003827261b72b7ea8f1594ba3ecf050cfdc"
 dependencies = [
  "arboard",
  "bevy",
@@ -536,6 +538,16 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "bevy_crossbeam_event"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f283116b8ea74be21e44b6c66f7442a8d0192b3790cdcca0b036a9675ce33b3c"
+dependencies = [
+ "bevy",
+ "crossbeam-channel",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,6 @@ serde_json = "1.0.113"
 serde = { version = "1.0.197", features = ["derive"] }
 
 [dev-dependencies]
-bevy_cosmic_edit = { git = "https://github.com/StaffEngineer/bevy_cosmic_edit" }
+bevy_cosmic_edit = "0.20.0"
 # bevy_cosmic_edit = { path = "../bevy_cosmic_edit" }
 bevy_mod_debugdump = "0.10.0"

--- a/crates/bevy-realtime/Cargo.toml
+++ b/crates/bevy-realtime/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "https://docs.rs/bevy-supabase-realtime"
 
 [dependencies]
 bevy = "0.13.0"
+bevy_crossbeam_event = "0.5.0"
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel", "crossbeam-deque"] }
 native-tls = "0.2.11"
 serde = "1.0.201"

--- a/crates/bevy-realtime/examples/broadcast.rs
+++ b/crates/bevy-realtime/examples/broadcast.rs
@@ -2,13 +2,13 @@ use std::{collections::HashMap, time::Duration};
 
 use bevy::prelude::*;
 use bevy_realtime::{
-    broadcast::bevy::{AppExtend as _, BroadcastForwarder, BroadcastPayloadEvent},
+    broadcast::bevy::{BroadcastEventApp, BroadcastForwarder, BroadcastPayloadEvent},
     message::payload::{BroadcastConfig, BroadcastPayload},
     BevyChannelBuilder, BuildChannel, Channel, Client, RealtimePlugin,
 };
 use serde_json::Value;
 
-#[derive(Event, Debug, Default)]
+#[derive(Event, Debug, Default, Clone)]
 pub struct ExBroadcastEvent {
     payload: HashMap<String, Value>,
 }

--- a/crates/bevy-realtime/examples/postgres.rs
+++ b/crates/bevy-realtime/examples/postgres.rs
@@ -4,12 +4,12 @@ use bevy_realtime::{
         payload::{PostgresChangesEvent, PostgresChangesPayload},
         postgres_change_filter::PostgresChangeFilter,
     },
-    postgres_changes::bevy::{AppExtend as _, PostgresForwarder, PostgresPayloadEvent},
+    postgres_changes::bevy::{PostgresForwarder, PostgresPayloadEvent, PostresEventApp as _},
     BevyChannelBuilder, BuildChannel, Client, RealtimePlugin,
 };
 
 #[allow(dead_code)]
-#[derive(Event, Debug)]
+#[derive(Event, Debug, Clone)]
 pub struct ExPostgresEvent {
     payload: PostgresChangesPayload,
 }

--- a/crates/bevy-realtime/examples/postgres_authed.rs
+++ b/crates/bevy-realtime/examples/postgres_authed.rs
@@ -6,12 +6,12 @@ use bevy_realtime::{
         payload::{PostgresChangesEvent, PostgresChangesPayload},
         postgres_change_filter::PostgresChangeFilter,
     },
-    postgres_changes::bevy::{AppExtend as _, PostgresForwarder, PostgresPayloadEvent},
+    postgres_changes::bevy::{PostgresForwarder, PostgresPayloadEvent, PostresEventApp as _},
     BevyChannelBuilder, BuildChannel, Client as RealtimeClient, RealtimePlugin,
 };
 
 #[allow(dead_code)]
-#[derive(Event, Debug)]
+#[derive(Event, Debug, Clone)]
 pub struct ExPostgresEvent {
     payload: PostgresChangesPayload,
 }

--- a/crates/bevy-realtime/examples/presence.rs
+++ b/crates/bevy-realtime/examples/presence.rs
@@ -9,7 +9,7 @@ use bevy_realtime::{
 };
 
 #[allow(dead_code)]
-#[derive(Event, Debug, Default)]
+#[derive(Event, Debug, Default, Clone)]
 pub struct ExPresenceEvent {
     key: String,
     new_state: PresenceState,

--- a/crates/bevy-realtime/src/broadcast.rs
+++ b/crates/bevy-realtime/src/broadcast.rs
@@ -18,7 +18,7 @@ pub mod bevy {
             &mut self,
         ) -> &mut Self {
             self.add_crossbeam_event::<E>()
-                .add_systems(Update, (broadcast_forward::<E, F>).chain())
+                .add_systems(Update, (broadcast_forward::<E, F>,))
         }
     }
 

--- a/crates/bevy-realtime/src/lib.rs
+++ b/crates/bevy-realtime/src/lib.rs
@@ -13,7 +13,6 @@ use bevy::{
 };
 use channel::{ChannelBuilder, ChannelManager};
 use client::{ClientBuilder, ClientManager, NextMessageError};
-use crossbeam::channel::{Receiver, TryRecvError};
 
 use crate::presence::bevy::{presence_untrack, update_presence_track};
 
@@ -23,33 +22,8 @@ pub struct Client(pub ClientManager);
 #[derive(Component, Deref, DerefMut)]
 pub struct BevyChannelBuilder(pub ChannelBuilder);
 
-#[derive(Component)]
-pub struct ChannelForwarder<E: Event> {
-    rx: Receiver<E>,
-}
-
 #[derive(Component, Deref, DerefMut)]
 pub struct Channel(pub ChannelManager);
-
-pub fn forwarder_recv<E: Event>(
-    mut commands: Commands,
-    mut q_forwarders: Query<(Entity, &mut ChannelForwarder<E>)>,
-    mut evw: EventWriter<E>,
-) {
-    for (e, c) in q_forwarders.iter_mut() {
-        match c.rx.try_recv() {
-            Ok(ev) => {
-                evw.send(ev);
-            }
-            Err(err) => match err {
-                TryRecvError::Empty => continue,
-                TryRecvError::Disconnected => {
-                    commands.entity(e).despawn();
-                }
-            },
-        }
-    }
-}
 
 #[derive(Component)]
 pub struct BuildChannel;

--- a/crates/bevy-realtime/src/postgres_changes.rs
+++ b/crates/bevy-realtime/src/postgres_changes.rs
@@ -2,35 +2,32 @@ pub mod bevy {
     use std::marker::PhantomData;
 
     use bevy::prelude::*;
-    use crossbeam::channel::unbounded;
+    use bevy_crossbeam_event::{CrossbeamEventApp, CrossbeamEventSender};
 
     use crate::{
-        forwarder_recv,
         message::{
             payload::{PostgresChangesEvent, PostgresChangesPayload},
             postgres_change_filter::PostgresChangeFilter,
         },
-        BevyChannelBuilder, ChannelForwarder,
+        BevyChannelBuilder,
     };
 
     pub trait PostgresPayloadEvent {
         fn new(payload: PostgresChangesPayload) -> Self;
     }
 
-    pub trait AppExtend {
-        fn add_postgres_event<E: Event + PostgresPayloadEvent, F: Component>(
+    pub trait PostresEventApp {
+        fn add_postgres_event<E: Event + PostgresPayloadEvent + Clone, F: Component>(
             &mut self,
         ) -> &mut Self;
     }
 
-    impl AppExtend for App {
-        fn add_postgres_event<E: Event + PostgresPayloadEvent, F: Component>(
+    impl PostresEventApp for App {
+        fn add_postgres_event<E: Event + PostgresPayloadEvent + Clone, F: Component>(
             &mut self,
         ) -> &mut Self {
-            self.add_event::<E>().add_systems(
-                Update,
-                (postgres_forward::<E, F>, forwarder_recv::<E>).chain(),
-            )
+            self.add_crossbeam_event::<E>()
+                .add_systems(Update, (postgres_forward::<E, F>,).chain())
         }
     }
 
@@ -54,27 +51,22 @@ pub mod bevy {
         }
     }
 
-    // "consumes" PostgresForwarders, creates ChannelForwarders
-    pub fn postgres_forward<E: Event + PostgresPayloadEvent, T: Component>(
+    pub fn postgres_forward<E: Event + PostgresPayloadEvent + Clone, T: Component>(
         mut commands: Commands,
         mut q: Query<
             (Entity, &mut BevyChannelBuilder, &PostgresForwarder<E>),
             (Added<PostgresForwarder<E>>, With<T>),
         >,
+        sender: Res<CrossbeamEventSender<E>>,
     ) {
         for (e, mut cb, event) in q.iter_mut() {
-            let (tx, rx) = unbounded();
-
+            let s = sender.clone();
             cb.0.on_postgres_change(event.event.clone(), event.filter.clone(), move |payload| {
                 let ev = E::new(payload.clone());
-
-                tx.try_send(ev).unwrap();
+                s.send(ev);
             });
 
-            commands
-                .entity(e)
-                .insert(ChannelForwarder::<E> { rx })
-                .remove::<PostgresForwarder<E>>();
+            commands.entity(e).remove::<PostgresForwarder<E>>();
         }
     }
 }

--- a/crates/bevy-realtime/src/postgres_changes.rs
+++ b/crates/bevy-realtime/src/postgres_changes.rs
@@ -27,7 +27,7 @@ pub mod bevy {
             &mut self,
         ) -> &mut Self {
             self.add_crossbeam_event::<E>()
-                .add_systems(Update, (postgres_forward::<E, F>,).chain())
+                .add_systems(Update, (postgres_forward::<E, F>,))
         }
     }
 

--- a/crates/bevy-realtime/src/presence.rs
+++ b/crates/bevy-realtime/src/presence.rs
@@ -254,7 +254,7 @@ pub mod bevy {
             &mut self,
         ) -> &mut Self {
             self.add_crossbeam_event::<E>()
-                .add_systems(Update, (presence_forward::<E, F>,).chain())
+                .add_systems(Update, (presence_forward::<E, F>,))
         }
     }
 

--- a/crates/bevy-realtime/src/presence.rs
+++ b/crates/bevy-realtime/src/presence.rs
@@ -231,13 +231,12 @@ pub mod bevy {
     use std::{collections::HashMap, marker::PhantomData};
 
     use bevy::prelude::*;
-    use crossbeam::channel::unbounded;
+    use bevy_crossbeam_event::{CrossbeamEventApp, CrossbeamEventSender};
     use serde_json::Value;
 
     use crate::{
-        forwarder_recv,
         presence::{PresenceEvent, PresenceState},
-        BevyChannelBuilder, Channel, ChannelForwarder,
+        BevyChannelBuilder, Channel,
     };
 
     pub trait PresencePayloadEvent {
@@ -245,19 +244,17 @@ pub mod bevy {
     }
 
     pub trait AppExtend {
-        fn add_presence_event<E: Event + PresencePayloadEvent, F: Component>(
+        fn add_presence_event<E: Event + PresencePayloadEvent + Clone, F: Component>(
             &mut self,
         ) -> &mut Self;
     }
 
     impl AppExtend for App {
-        fn add_presence_event<E: Event + PresencePayloadEvent, F: Component>(
+        fn add_presence_event<E: Event + PresencePayloadEvent + Clone, F: Component>(
             &mut self,
         ) -> &mut Self {
-            self.add_event::<E>().add_systems(
-                Update,
-                (presence_forward::<E, F>, forwarder_recv::<E>).chain(),
-            )
+            self.add_crossbeam_event::<E>()
+                .add_systems(Update, (presence_forward::<E, F>,).chain())
         }
     }
 
@@ -276,27 +273,22 @@ pub mod bevy {
         }
     }
 
-    // "consumes" PresenceForwarders, creates ChannelForwarders
-    pub fn presence_forward<E: Event + PresencePayloadEvent, T: Component>(
+    pub fn presence_forward<E: Event + PresencePayloadEvent + Clone, T: Component>(
         mut commands: Commands,
         mut q: Query<
             (Entity, &mut BevyChannelBuilder, &PresenceForwarder<E>),
             (Added<PresenceForwarder<E>>, With<T>),
         >,
+        sender: Res<CrossbeamEventSender<E>>,
     ) {
         for (e, mut cb, event) in q.iter_mut() {
-            let (tx, rx) = unbounded();
-
+            let s = sender.clone();
             cb.0.on_presence(event.event.clone(), move |key, old, new| {
                 let ev = E::new(key, old, new);
-
-                tx.try_send(ev).unwrap();
+                s.send(ev);
             });
 
-            commands
-                .entity(e)
-                .insert(ChannelForwarder::<E> { rx })
-                .remove::<PresenceForwarder<E>>();
+            commands.entity(e).remove::<PresenceForwarder<E>>();
         }
     }
 
@@ -311,7 +303,6 @@ pub mod bevy {
         q: Query<(&PrescenceTrack, &Channel), Or<(Changed<PrescenceTrack>, Added<Channel>)>>,
     ) {
         for (p, c) in q.iter() {
-            println!("RUNNUNG SYSTEM");
             c.track(p.payload.clone()).unwrap();
         }
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,6 +4,6 @@ pub use bevy_realtime::{
         payload::{PostgresChangesEvent, PostgresChangesPayload},
         postgres_change_filter::PostgresChangeFilter,
     },
-    postgres_changes::bevy::{AppExtend as _, PostgresForwarder, PostgresPayloadEvent},
+    postgres_changes::bevy::{PostgresForwarder, PostgresPayloadEvent, PostresEventApp as _},
     BevyChannelBuilder, BuildChannel, Client, RealtimePlugin,
 };


### PR DESCRIPTION
\+ dependency
\- local code to maintain

Should allow for deeper use of bevy events in communicating with a `bevy_realtime::Client` running on a separate thread, contributing to a fix for bytemunch/bevy-realtime#3 and bytemunch/bevy-realtime#4