### PR TITLE
Crossbeam events everywhere

### DIFF
--- a/crates/bevy-realtime/examples/broadcast.rs
+++ b/crates/bevy-realtime/examples/broadcast.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashMap, time::Duration};
 
-use bevy::prelude::*;
+use bevy::{ecs::system::SystemId, prelude::*, time::common_conditions::on_timer};
 use bevy_realtime::{
     broadcast::bevy::{BroadcastEventApp, BroadcastForwarder, BroadcastPayloadEvent},
-    channel::ChannelBuilder,
+    channel::{ChannelBuilder, ChannelState},
     client_ready,
     message::payload::{BroadcastConfig, BroadcastPayload},
     BevyChannelBuilder, BuildChannel, Channel, Client, RealtimePlugin,
@@ -21,9 +21,6 @@ impl BroadcastPayloadEvent for ExBroadcastEvent {
     }
 }
 
-#[derive(Resource)]
-pub struct TestTimer(pub Timer);
-
 fn main() {
     let mut app = App::new();
 
@@ -35,12 +32,13 @@ fn main() {
         .add_systems(Startup, (setup,))
         .add_systems(
             Update,
-            (
-                (tick_timer, say_cheese),
-                (send_every_second, evr_broadcast)
-                    .chain()
-                    .run_if(client_ready),
-            ),
+            ((
+                (send_every_second, test_get_channel_state)
+                    .run_if(on_timer(Duration::from_secs(1))),
+                evr_broadcast,
+            )
+                .chain()
+                .run_if(client_ready),),
         )
         .add_broadcast_event::<ExBroadcastEvent, BevyChannelBuilder>();
 
@@ -51,15 +49,14 @@ fn setup(world: &mut World) {
     println!("setup s1 ");
 
     world.spawn(Camera2dBundle::default());
-    world.insert_resource(TestTimer(Timer::new(
-        Duration::from_secs(1),
-        TimerMode::Repeating,
-    )));
 
     let callback = world.register_system(build_channel_callback);
     let client = world.resource::<Client>();
 
     client.channel(callback).unwrap();
+
+    let test_callback = world.register_system(get_channel_state);
+    world.insert_resource(TestCallback(test_callback));
 
     println!("setup s1 finished");
 }
@@ -87,23 +84,21 @@ fn evr_broadcast(mut evr: EventReader<ExBroadcastEvent>) {
     }
 }
 
-fn tick_timer(mut timer: ResMut<TestTimer>, time: Res<Time>) {
-    timer.0.tick(time.delta());
+#[derive(Resource, Deref)]
+struct TestCallback(pub SystemId<ChannelState>);
+
+fn test_get_channel_state(channel: Query<&Channel>, callback: Res<TestCallback>) {
+    println!("Get state...");
+    for c in channel.iter() {
+        c.channel_state(**callback).unwrap();
+    }
 }
 
-// This is here to check that bevy systems are running in parallel
-fn say_cheese(timer: Res<TestTimer>, mut count: Local<usize>) {
-    if !timer.0.just_finished() {
-        return;
-    }
-    info!("che{}ese", "e".repeat(*count));
-    *count += 1;
+fn get_channel_state(state: In<ChannelState>) {
+    println!("State got! {:?}", *state);
 }
 
-fn send_every_second(q_channel: Query<&Channel>, timer: Res<TestTimer>) {
-    if !timer.0.just_finished() {
-        return;
-    }
+fn send_every_second(q_channel: Query<&Channel>) {
     let mut payload = HashMap::new();
     payload.insert("bevy?".into(), "bavy.".into());
     for c in q_channel.iter() {

--- a/crates/bevy-realtime/examples/broadcast.rs
+++ b/crates/bevy-realtime/examples/broadcast.rs
@@ -68,7 +68,7 @@ fn setup_channels(mut commands: Commands, client: Res<Client>, mut has_run: Loca
 
     c.insert(BuildChannel);
 
-    println!("setup finished");
+    println!("channel setup finished");
 }
 
 fn bevy_setup(mut commands: Commands) {
@@ -89,6 +89,7 @@ fn tick_timer(mut timer: ResMut<TestTimer>, time: Res<Time>) {
     timer.0.tick(time.delta());
 }
 
+// This is here to check that bevy systems are running in parallel
 fn say_cheese(timer: Res<TestTimer>, mut count: Local<usize>) {
     if !timer.0.just_finished() {
         return;

--- a/crates/bevy-realtime/examples/broadcast.rs
+++ b/crates/bevy-realtime/examples/broadcast.rs
@@ -55,9 +55,9 @@ fn setup_channels(mut commands: Commands, client: Res<Client>, mut has_run: Loca
 
     *has_run = true;
 
-    let mut channel = client.channel("test".into());
+    let mut channel = client.channel();
 
-    channel.set_broadcast_config(BroadcastConfig {
+    channel.topic("test").set_broadcast_config(BroadcastConfig {
         broadcast_self: true,
         ack: false,
     });

--- a/crates/bevy-realtime/examples/broadcast.rs
+++ b/crates/bevy-realtime/examples/broadcast.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, time::Duration};
 use bevy::prelude::*;
 use bevy_realtime::{
     broadcast::bevy::{AppExtend as _, BroadcastForwarder, BroadcastPayloadEvent},
+    client_ready,
     message::payload::{BroadcastConfig, BroadcastPayload},
     BevyChannelBuilder, BuildChannel, Channel, Client, RealtimePlugin,
 };
@@ -30,15 +31,29 @@ fn main() {
             "http://127.0.0.1:54321/realtime/v1".into(),
             std::env::var("SUPABASE_LOCAL_ANON_KEY").unwrap(),
         ),))
-        .add_systems(Startup, (setup,))
-        .add_systems(Update, (send_every_second, evr_broadcast).chain())
+        .add_systems(Startup, (bevy_setup,))
+        .add_systems(
+            Update,
+            (
+                (tick_timer, say_cheese),
+                (send_every_second, evr_broadcast, setup_channels)
+                    .chain()
+                    .run_if(client_ready),
+            ),
+        )
         .add_broadcast_event::<ExBroadcastEvent, BevyChannelBuilder>();
 
     app.run()
 }
 
-fn setup(mut commands: Commands, client: Res<Client>) {
-    commands.spawn(Camera2dBundle::default());
+fn setup_channels(mut commands: Commands, client: Res<Client>, mut has_run: Local<bool>) {
+    if *has_run {
+        return;
+    }
+
+    println!("running channel setup");
+
+    *has_run = true;
 
     let mut channel = client.channel("test".into());
 
@@ -53,6 +68,11 @@ fn setup(mut commands: Commands, client: Res<Client>) {
 
     c.insert(BuildChannel);
 
+    println!("setup finished");
+}
+
+fn bevy_setup(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
     commands.insert_resource(TestTimer(Timer::new(
         Duration::from_secs(1),
         TimerMode::Repeating,
@@ -65,8 +85,19 @@ fn evr_broadcast(mut evr: EventReader<ExBroadcastEvent>) {
     }
 }
 
-fn send_every_second(q_channel: Query<&Channel>, mut timer: ResMut<TestTimer>, time: Res<Time>) {
+fn tick_timer(mut timer: ResMut<TestTimer>, time: Res<Time>) {
     timer.0.tick(time.delta());
+}
+
+fn say_cheese(timer: Res<TestTimer>, mut count: Local<usize>) {
+    if !timer.0.just_finished() {
+        return;
+    }
+    info!("che{}ese", "e".repeat(*count));
+    *count += 1;
+}
+
+fn send_every_second(q_channel: Query<&Channel>, timer: Res<TestTimer>) {
     if !timer.0.just_finished() {
         return;
     }

--- a/crates/bevy-realtime/examples/broadcast.rs
+++ b/crates/bevy-realtime/examples/broadcast.rs
@@ -46,8 +46,6 @@ fn main() {
 }
 
 fn setup(world: &mut World) {
-    println!("setup s1 ");
-
     world.spawn(Camera2dBundle::default());
 
     let callback = world.register_system(build_channel_callback);
@@ -57,12 +55,9 @@ fn setup(world: &mut World) {
 
     let test_callback = world.register_system(get_channel_state);
     world.insert_resource(TestCallback(test_callback));
-
-    println!("setup s1 finished");
 }
 
 fn build_channel_callback(mut channel_builder: In<ChannelBuilder>, mut commands: Commands) {
-    println!("channel setup s2 ");
     channel_builder
         .topic("test")
         .set_broadcast_config(BroadcastConfig {
@@ -75,7 +70,6 @@ fn build_channel_callback(mut channel_builder: In<ChannelBuilder>, mut commands:
     c.insert(BroadcastForwarder::<ExBroadcastEvent>::new("test".into()));
 
     c.insert(BuildChannel);
-    println!("channel setup s2 finished");
 }
 
 fn evr_broadcast(mut evr: EventReader<ExBroadcastEvent>) {
@@ -88,7 +82,6 @@ fn evr_broadcast(mut evr: EventReader<ExBroadcastEvent>) {
 struct TestCallback(pub SystemId<ChannelState>);
 
 fn test_get_channel_state(channel: Query<&Channel>, callback: Res<TestCallback>) {
-    println!("Get state...");
     for c in channel.iter() {
         c.channel_state(**callback).unwrap();
     }

--- a/crates/bevy-realtime/examples/postgres.rs
+++ b/crates/bevy-realtime/examples/postgres.rs
@@ -37,7 +37,9 @@ fn main() {
 fn setup(mut commands: Commands, client: Res<Client>) {
     commands.spawn(Camera2dBundle::default());
 
-    let channel = client.channel("test".into());
+    let mut channel = client.channel();
+
+    channel.topic("test");
 
     let mut c = commands.spawn(BevyChannelBuilder(channel));
 

--- a/crates/bevy-realtime/examples/postgres_authed.rs
+++ b/crates/bevy-realtime/examples/postgres_authed.rs
@@ -54,7 +54,9 @@ fn setup(mut commands: Commands, client: Res<RealtimeClient>, auth: Res<AuthClie
         },
     );
 
-    let channel = client.channel("test".into());
+    let mut channel = client.channel();
+
+    channel.topic("test");
 
     let mut c = commands.spawn(BevyChannelBuilder(channel));
 

--- a/crates/bevy-realtime/examples/postgres_authed.rs
+++ b/crates/bevy-realtime/examples/postgres_authed.rs
@@ -71,7 +71,9 @@ fn setup(mut commands: Commands, client: Res<RealtimeClient>, auth: Res<AuthClie
 }
 
 fn signed_in(client: Res<RealtimeClient>, auth: Res<AuthClient>) {
-    client.set_access_token(auth.access_token.clone().unwrap())
+    client
+        .set_access_token(auth.access_token.clone().unwrap())
+        .unwrap();
 }
 
 fn evr_postgres(mut evr: EventReader<ExPostgresEvent>) {

--- a/crates/bevy-realtime/examples/presence.rs
+++ b/crates/bevy-realtime/examples/presence.rs
@@ -43,9 +43,9 @@ fn main() {
 fn setup(mut commands: Commands, client: Res<Client>) {
     commands.spawn(Camera2dBundle::default());
 
-    let mut channel = client.channel("test".into());
+    let mut channel = client.channel();
 
-    channel.set_presence_config(PresenceConfig {
+    channel.topic("test").set_presence_config(PresenceConfig {
         key: Some("TestPresKey".into()),
     });
 

--- a/crates/bevy-realtime/src/broadcast.rs
+++ b/crates/bevy-realtime/src/broadcast.rs
@@ -5,7 +5,7 @@ pub mod bevy {
     use crossbeam::channel::unbounded;
     use serde_json::Value;
 
-    use crate::{forwarder_recv, BevyChannelBuilder, ChannelForwarder};
+    use crate::{client_ready, forwarder_recv, BevyChannelBuilder, ChannelForwarder};
 
     pub trait AppExtend {
         fn add_broadcast_event<E: Event + BroadcastPayloadEvent, F: Component>(
@@ -19,7 +19,9 @@ pub mod bevy {
         ) -> &mut Self {
             self.add_event::<E>().add_systems(
                 Update,
-                (broadcast_forward::<E, F>, forwarder_recv::<E>).chain(),
+                (broadcast_forward::<E, F>, forwarder_recv::<E>)
+                    .chain()
+                    .run_if(client_ready),
             )
         }
     }

--- a/crates/bevy-realtime/src/channel.rs
+++ b/crates/bevy-realtime/src/channel.rs
@@ -484,24 +484,26 @@ impl ChannelBuilder {
     pub fn build(&self, client: &ClientManager) -> ChannelManager {
         let manager_channel = unbounded();
 
-        client.add_channel(RealtimeChannel {
-            topic: self.topic.clone(),
-            cdc_callbacks: self.cdc_callbacks.clone(),
-            broadcast_callbacks: self.broadcast_callbacks.clone(),
-            tx: self.tx.clone(),
-            manager_rx: manager_channel.1,
-            connection_state: ChannelState::Closed,
-            id: self.id,
-            join_payload: JoinPayload {
-                config: JoinConfig {
-                    broadcast: self.broadcast.clone(),
-                    presence: self.presence.clone(),
-                    postgres_changes: self.postgres_changes.clone(),
+        client
+            .add_channel(RealtimeChannel {
+                topic: self.topic.clone(),
+                cdc_callbacks: self.cdc_callbacks.clone(),
+                broadcast_callbacks: self.broadcast_callbacks.clone(),
+                tx: self.tx.clone(),
+                manager_rx: manager_channel.1,
+                connection_state: ChannelState::Closed,
+                id: self.id,
+                join_payload: JoinPayload {
+                    config: JoinConfig {
+                        broadcast: self.broadcast.clone(),
+                        presence: self.presence.clone(),
+                        postgres_changes: self.postgres_changes.clone(),
+                    },
+                    access_token: self.access_token.clone(),
                 },
-                access_token: self.access_token.clone(),
-            },
-            presence: Presence::from_channel_builder(self.presence_callbacks.clone()),
-        });
+                presence: Presence::from_channel_builder(self.presence_callbacks.clone()),
+            })
+            .unwrap();
 
         ChannelManager {
             tx: manager_channel.0,

--- a/crates/bevy-realtime/src/channel.rs
+++ b/crates/bevy-realtime/src/channel.rs
@@ -393,7 +393,7 @@ impl ChannelBuilder {
     }
 
     /// Set the topic of the channel
-    pub fn topic(mut self, topic: impl Into<String>) -> Self {
+    pub fn topic(&mut self, topic: impl Into<String>) -> &mut Self {
         self.topic = format!("realtime:{}", topic.into());
         self
     }

--- a/crates/bevy-realtime/src/channel.rs
+++ b/crates/bevy-realtime/src/channel.rs
@@ -1,4 +1,4 @@
-use bevy::log::debug;
+use bevy::{ecs::event::Event, log::debug};
 use crossbeam::channel::{unbounded, Receiver, SendError, Sender};
 use serde_json::Value;
 use uuid::Uuid;
@@ -363,6 +363,7 @@ impl Debug for RealtimeChannel {
 /// Builder struct for [RealtimeChannel]
 ///
 /// Get access to this through [RealtimeClient::channel()]
+#[derive(Event, Clone)]
 pub struct ChannelBuilder {
     topic: String,
     access_token: String,

--- a/crates/bevy-realtime/src/client.rs
+++ b/crates/bevy-realtime/src/client.rs
@@ -223,20 +223,6 @@ pub struct Client {
     channel_callback_event_sender: CrossbeamEventSender<ChannelCallbackEvent>,
 }
 
-impl Debug for Client {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // TODO this is horrid
-        f.write_fmt(format_args!(
-            "{:?} {:?} {:?} {:?}  {}",
-            self.socket,
-            self.channels,
-            self.inbound_channel.0,
-            self.outbound_channel.0,
-            "TODO middleware debug fmt"
-        ))
-    }
-}
-
 #[derive(Event, Clone)]
 pub struct ChannelCallbackEvent(pub (SystemId<ChannelBuilder>, ChannelBuilder));
 
@@ -526,7 +512,11 @@ impl Client {
         }
 
         if channel.connection_state != ChannelState::Joining {
-            self.channels.get_mut(&channel_id).unwrap().subscribe();
+            self.channels
+                .get_mut(&channel_id)
+                .unwrap()
+                .subscribe()
+                .unwrap();
         }
 
         loop {
@@ -787,7 +777,7 @@ impl Client {
                     match self.connect() {
                         Ok(_) => {
                             for channel in self.channels.values_mut() {
-                                channel.subscribe();
+                                channel.subscribe().unwrap();
                             }
 
                             Ok(())

--- a/crates/bevy-realtime/src/client.rs
+++ b/crates/bevy-realtime/src/client.rs
@@ -1007,7 +1007,7 @@ impl ClientBuilder {
     }
 
     /// Sets the client headers. Headers always contain "X-Client-Info: realtime-rs/{version}".
-    pub fn set_headers(mut self, set_headers: HeaderMap) -> Self {
+    pub fn set_headers(&mut self, set_headers: HeaderMap) -> &mut Self {
         let mut headers = HeaderMap::new();
         headers.insert("X-Client-Info", "realtime-rs/0.1.0".parse().unwrap());
         headers.extend(set_headers);
@@ -1018,19 +1018,19 @@ impl ClientBuilder {
     }
 
     /// Merges provided [HeaderMap] with currently held headers
-    pub fn add_headers(mut self, headers: HeaderMap) -> Self {
+    pub fn add_headers(&mut self, headers: HeaderMap) -> &mut Self {
         self.headers.extend(headers);
         self
     }
 
     /// Set endpoint URL params
-    pub fn params(mut self, params: HashMap<String, String>) -> Self {
+    pub fn params(&mut self, params: HashMap<String, String>) -> &mut Self {
         self.params = Some(params);
         self
     }
 
     /// Set [Duration] between heartbeat packets. Default 29 seconds.
-    pub fn heartbeat_interval(mut self, heartbeat_interval: Duration) -> Self {
+    pub fn heartbeat_interval(&mut self, heartbeat_interval: Duration) -> &mut Self {
         self.heartbeat_interval = heartbeat_interval;
         self
     }
@@ -1043,7 +1043,7 @@ impl ClientBuilder {
     /// requests.
     ///
     /// Defaults to stepped backoff
-    pub fn reconnect_interval(mut self, reconnect_interval: ReconnectFn) -> Self {
+    pub fn reconnect_interval(&mut self, reconnect_interval: ReconnectFn) -> &mut Self {
         // TODO minimum interval to prevent 10000000 requests in seconds
         // then again it takes a bit of work to make that mistake?
         self.reconnect_interval = reconnect_interval;
@@ -1051,7 +1051,7 @@ impl ClientBuilder {
     }
 
     /// Configure the number of recconect attempts to be made before erroring
-    pub fn reconnect_max_attempts(mut self, max_attempts: usize) -> Self {
+    pub fn reconnect_max_attempts(&mut self, max_attempts: usize) -> &mut Self {
         self.reconnect_max_attempts = max_attempts;
         self
     }
@@ -1059,7 +1059,7 @@ impl ClientBuilder {
     /// Configure the duration to wait for a connection to succeed.
     /// Default: 10 seconds
     /// Minimum: 1 second
-    pub fn connection_timeout(mut self, timeout: Duration) -> Self {
+    pub fn connection_timeout(&mut self, timeout: Duration) -> &mut Self {
         // 1 sec min timeout
         let timeout = if timeout < Duration::from_secs(1) {
             Duration::from_secs(1)
@@ -1074,30 +1074,30 @@ impl ClientBuilder {
     /// Set the base URL for the auth server
     /// In live supabase deployments this is the same as the endpoint URL, and defaults as such.
     /// In local deployments this may need to be set manually
-    pub fn auth_url(mut self, auth_url: impl Into<String>) -> Self {
+    pub fn auth_url(&mut self, auth_url: impl Into<String>) -> &mut Self {
         self.auth_url = Some(auth_url.into());
         self
     }
 
     /// Sets the max messages we can send in a second.
     /// Default: 10
-    pub fn max_events_per_second(mut self, count: usize) -> Self {
+    pub fn max_events_per_second(&mut self, count: usize) -> &mut Self {
         self.max_events_per_second = count;
         self
     }
 
     pub fn encode(
-        mut self,
+        &mut self,
         encode: impl Fn(RealtimeMessage) -> RealtimeMessage + 'static + Send + Sync,
-    ) -> Self {
+    ) -> &mut Self {
         self.encode = Some(Box::new(encode));
         self
     }
 
     pub fn decode(
-        mut self,
+        &mut self,
         decode: impl Fn(RealtimeMessage) -> RealtimeMessage + 'static + Send + Sync,
-    ) -> Self {
+    ) -> &mut Self {
         self.decode = Some(Box::new(decode));
         self
     }

--- a/crates/bevy-realtime/src/client.rs
+++ b/crates/bevy-realtime/src/client.rs
@@ -11,8 +11,8 @@ use std::{
     time::Duration,
 };
 
-use bevy::log::debug;
-use crossbeam::channel::{unbounded, Receiver, SendError, Sender, TryRecvError};
+use bevy::log::{debug, info};
+use crossbeam::channel::{unbounded, Receiver, RecvError, SendError, Sender, TryRecvError};
 use native_tls::TlsConnector;
 use tungstenite::{client, Message};
 use tungstenite::{
@@ -140,6 +140,9 @@ pub enum ClientManagerMessage {
     SetAccessToken {
         token: String,
     },
+    ConnectionState {
+        tx: Sender<ConnectionState>,
+    },
 }
 
 impl ClientManager {
@@ -148,6 +151,18 @@ impl ClientManager {
             tx: client.manager_tx.clone(),
         }
     }
+
+    // TODO ClientManager should hold ready state
+    // all fns should consult ready state before trying to interact across async bounds
+    //
+    // OR
+    //
+    // ClienManager should be polled each frame, and send events on reciept of data from across
+    // async bounds
+    //
+    // OR
+    //
+    // Client should have a tx that sends to an rx on main thread, updating the connection state
 
     pub fn channel(&self, topic: String) -> ChannelBuilder {
         let (tx, rx) = unbounded();
@@ -178,12 +193,21 @@ impl ClientManager {
             .send(ClientManagerMessage::SetAccessToken { token })
             .unwrap();
     }
+
+    pub fn connection_state(&self) -> Result<ConnectionState, RecvError> {
+        let (tx, rx) = unbounded();
+        self.tx
+            .send(ClientManagerMessage::ConnectionState { tx })
+            .unwrap();
+
+        rx.recv()
+    }
 }
 
 /// Synchronous websocket client that interfaces with Supabase Realtime
 pub struct Client {
     pub(crate) access_token: String,
-    status: ConnectionState,
+    connection_state: ConnectionState,
     socket: Option<WebSocket>,
     channels: HashMap<Uuid, RealtimeChannel>,
     messages_this_second: Vec<SystemTime>,
@@ -239,6 +263,9 @@ impl Client {
                 ClientManagerMessage::SetAccessToken { token } => {
                     self.access_token = token;
                 }
+                ClientManagerMessage::ConnectionState { tx } => {
+                    tx.send(self.connection_state)?;
+                }
             }
         }
 
@@ -251,7 +278,7 @@ impl Client {
 
     /// Returns this client's [ConnectionState]
     pub fn get_status(&self) -> ConnectionState {
-        self.status
+        self.connection_state
     }
 
     /// Returns a new [RealtimeChannelBuilder] instantiated with the provided `topic`
@@ -261,7 +288,7 @@ impl Client {
 
     /// Attempt to create a websocket connection with the server
     pub fn connect(&mut self) -> Result<&mut Client, ConnectError> {
-        println!("connecting...");
+        info!("connecting...");
 
         let uri: Uri = match format!(
             "{}/websocket?apikey={}&vsn=1.0.0",
@@ -431,28 +458,29 @@ impl Client {
 
         self.socket = Some(socket);
 
-        self.status = ConnectionState::Open;
+        self.connection_state = ConnectionState::Open;
+        info!("connected");
 
         Ok(self)
     }
 
     /// Disconnect the client
     pub fn disconnect(&mut self) {
-        if self.status == ConnectionState::Closed {
+        if self.connection_state == ConnectionState::Closed {
             return;
         }
 
         self.remove_all_channels();
 
-        self.status = ConnectionState::Closed;
+        self.connection_state = ConnectionState::Closed;
 
         let Some(ref mut socket) = self.socket else {
-            debug!("Already disconnected. {:?}", self.status);
+            debug!("Already disconnected. {:?}", self.connection_state);
             return;
         };
 
         let _ = socket.close(None);
-        debug!("Client disconnected. {:?}", self.status);
+        debug!("Client disconnected. {:?}", self.connection_state);
     }
 
     /// Queues a [RealtimeMessage] for sending to the server
@@ -568,6 +596,7 @@ impl Client {
 
     /// The main step function for driving the [RealtimeClient]
     pub fn next_message(&mut self) -> Result<Vec<Uuid>, NextMessageError> {
+        // TODO run manager_recv fns until channels drained
         match self.manager_recv() {
             Ok(()) => {}
             Err(e) => debug!("client manager_recv error: {}", e),
@@ -580,7 +609,7 @@ impl Client {
             }
         }
 
-        match self.status {
+        match self.connection_state {
             ConnectionState::Closed => {
                 return Err(NextMessageError::ClientClosed);
             }
@@ -666,11 +695,13 @@ impl Client {
     }
 
     fn remove_all_channels(&mut self) {
-        if self.status == ConnectionState::Closing || self.status == ConnectionState::Closed {
+        if self.connection_state == ConnectionState::Closing
+            || self.connection_state == ConnectionState::Closed
+        {
             return;
         }
 
-        self.status = ConnectionState::Closing;
+        self.connection_state = ConnectionState::Closing;
 
         // wait until inbound_rx is drained
         loop {
@@ -747,8 +778,8 @@ impl Client {
         match self.monitor_channel.0 .1.try_recv() {
             Ok(signal) => match signal {
                 MonitorSignal::Reconnect => {
-                    if self.status == ConnectionState::Open
-                        || self.status == ConnectionState::Reconnecting
+                    if self.connection_state == ConnectionState::Open
+                        || self.connection_state == ConnectionState::Reconnecting
                         || SystemTime::now() < self.reconnect_now.unwrap() + self.reconnect_delay
                     {
                         return Err(MonitorError::WouldBlock);
@@ -758,7 +789,7 @@ impl Client {
                         return Err(MonitorError::MaxReconnects);
                     }
 
-                    self.status = ConnectionState::Reconnecting;
+                    self.connection_state = ConnectionState::Reconnecting;
                     self.reconnect_attempts += 1;
                     self.reconnect_now.take();
 
@@ -772,7 +803,7 @@ impl Client {
                         }
                         Err(e) => {
                             debug!("reconnect error: {:?}", e);
-                            self.status = ConnectionState::Reconnect;
+                            self.connection_state = ConnectionState::Reconnect;
                             Err(MonitorError::ReconnectError)
                         }
                     }
@@ -841,7 +872,7 @@ impl Client {
             }
             Err(err) => {
                 debug!("Socket read error: {:?}", err);
-                self.status = ConnectionState::Reconnect;
+                self.connection_state = ConnectionState::Reconnect;
                 let _ = self.monitor_channel.0 .0.send(MonitorSignal::Reconnect);
                 Err(SocketError::WouldBlock)
             }
@@ -902,7 +933,7 @@ impl Client {
             }
             Err(e) => {
                 debug!("outbound error: {:?}", e);
-                self.status = ConnectionState::Reconnect;
+                self.connection_state = ConnectionState::Reconnect;
                 let _ = self.monitor_channel.0 .0.send(MonitorSignal::Reconnect);
                 Err(SocketError::WouldBlock)
             }
@@ -910,7 +941,7 @@ impl Client {
     }
 
     fn reconnect(&mut self) {
-        self.status = ConnectionState::Reconnect;
+        self.connection_state = ConnectionState::Reconnect;
         let _ = self.monitor_channel.0 .0.send(MonitorSignal::Reconnect);
     }
 }
@@ -1011,28 +1042,7 @@ impl ClientBuilder {
     /// Don't implement an untested timing function here in prod or you might make a few too many
     /// requests.
     ///
-    /// Defaults to stepped backoff, as shown below
-    /// ```
-    /// # use std::env;
-    /// # use std::time::Duration;
-    /// # use realtime_rs::sync::*;
-    /// # use realtime_rs::message::*;  
-    /// # use realtime_rs::*;          
-    /// # fn main() -> Result<(), ()> {
-    ///     fn backoff(attempts: usize) -> Duration {
-    ///         let times: Vec<u64> = vec![0, 1, 2, 5, 10];
-    ///         Duration::from_secs(times[attempts.min(times.len() - 1)])
-    ///     }
-    ///
-    ///     let url = "http://127.0.0.1:54321";
-    ///     let anon_key = env::var("LOCAL_ANON_KEY").expect("No anon key!");
-    ///
-    ///     let mut client = RealtimeClientBuilder::new(url, anon_key)
-    ///         .reconnect_interval(ReconnectFn::new(backoff))
-    ///         .build();
-    /// #   Ok(())
-    /// # }
-    ///
+    /// Defaults to stepped backoff
     pub fn reconnect_interval(mut self, reconnect_interval: ReconnectFn) -> Self {
         // TODO minimum interval to prevent 10000000 requests in seconds
         // then again it takes a bit of work to make that mistake?
@@ -1109,7 +1119,7 @@ impl ClientBuilder {
             access_token: self.access_token,
             max_events_per_second: self.max_events_per_second,
             next_ref: Uuid::new_v4(),
-            status: Default::default(),
+            connection_state: Default::default(),
             socket: Default::default(),
             channels: Default::default(),
             messages_this_second: Default::default(),

--- a/crates/bevy-realtime/src/lib.rs
+++ b/crates/bevy-realtime/src/lib.rs
@@ -118,13 +118,11 @@ pub fn client_ready(
     client: Res<Client>,
     sender: Res<CrossbeamEventSender<ConnectionState>>,
 ) -> bool {
-    if *rate_limiter % 30 != 0 {
-        return *last_state == ConnectionState::Open;
+    *rate_limiter += 1;
+    if *rate_limiter % 30 == 0 {
+        *rate_limiter = 0;
+        client.connection_state(sender.clone()).unwrap_or(());
     }
-
-    *rate_limiter = 0;
-
-    client.connection_state(sender.clone()).unwrap_or(());
 
     for ev in evr.read() {
         *last_state = ev.clone();

--- a/crates/bevy-realtime/src/lib.rs
+++ b/crates/bevy-realtime/src/lib.rs
@@ -120,8 +120,8 @@ impl Plugin for RealtimePlugin {
     }
 }
 
-fn run_callbacks(mut commands: Commands, mut evr: EventReader<ChannelCallbackEvent>) {
-    for ev in evr.read() {
+fn run_callbacks(mut commands: Commands, mut channel_evr: EventReader<ChannelCallbackEvent>) {
+    for ev in channel_evr.read() {
         let (callback, builder) = ev.0.clone();
         commands.run_system_with_input(callback, builder);
     }

--- a/crates/bevy-realtime/src/postgres_changes.rs
+++ b/crates/bevy-realtime/src/postgres_changes.rs
@@ -5,7 +5,7 @@ pub mod bevy {
     use crossbeam::channel::unbounded;
 
     use crate::{
-        forwarder_recv,
+        client_ready, forwarder_recv,
         message::{
             payload::{PostgresChangesEvent, PostgresChangesPayload},
             postgres_change_filter::PostgresChangeFilter,
@@ -29,7 +29,9 @@ pub mod bevy {
         ) -> &mut Self {
             self.add_event::<E>().add_systems(
                 Update,
-                (postgres_forward::<E, F>, forwarder_recv::<E>).chain(),
+                (postgres_forward::<E, F>, forwarder_recv::<E>)
+                    .chain()
+                    .run_if(client_ready),
             )
         }
     }

--- a/crates/bevy-realtime/src/presence.rs
+++ b/crates/bevy-realtime/src/presence.rs
@@ -235,7 +235,7 @@ pub mod bevy {
     use serde_json::Value;
 
     use crate::{
-        forwarder_recv,
+        client_ready, forwarder_recv,
         presence::{PresenceEvent, PresenceState},
         BevyChannelBuilder, Channel, ChannelForwarder,
     };
@@ -256,7 +256,9 @@ pub mod bevy {
         ) -> &mut Self {
             self.add_event::<E>().add_systems(
                 Update,
-                (presence_forward::<E, F>, forwarder_recv::<E>).chain(),
+                (presence_forward::<E, F>, forwarder_recv::<E>)
+                    .chain()
+                    .run_if(client_ready),
             )
         }
     }
@@ -311,7 +313,6 @@ pub mod bevy {
         q: Query<(&PrescenceTrack, &Channel), Or<(Changed<PrescenceTrack>, Added<Channel>)>>,
     ) {
         for (p, c) in q.iter() {
-            println!("RUNNUNG SYSTEM");
             c.track(p.payload.clone()).unwrap();
         }
     }

--- a/crates/bevy-realtime/src/presence.rs
+++ b/crates/bevy-realtime/src/presence.rs
@@ -139,7 +139,6 @@ impl Presence {
     }
 
     pub(crate) fn sync(&mut self, new_state: PresenceState) {
-        // TODO state? functional? Nah both mixed together. lol and also lmao even
         let joins: PresenceState = new_state
             .0
             .clone()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,10 @@ fn setup_apikey(
 }
 
 fn update_realtime_access_token(client: Res<RealtimeClient>, auth: Res<Session>) {
-    client.0.set_access_token(auth.access_token.clone())
+    client
+        .0
+        .set_access_token(auth.access_token.clone())
+        .unwrap();
 }
 
 fn update_postgrest_access_token(mut client: ResMut<PostgrestClient>, auth: Res<Session>) {


### PR DESCRIPTION
This is the branch I'm gonna be experimenting with new ways of talking to the RealtimeClient while it's on an async task.

So far I've got bevy's oneshot systems being called from the other thread with crossbeam events carrying input data. This feels like a powerful yet still ergonomic approach to the async messaging problem. Callback systems do need to be registered in exclusive systems, but this feels much better than other methods I've tried.

This approach allows for targeted callbacks on a per event (per ClientManager function call) basis, allowing for the async delay to be essentially ignored when programming, which should eradicate a lot of the remaining race conditions. (e.g. channels cannot be created until the client is ready to set them up).

This will be quite a rewrite, and uses a LOT of events, as one will be needed for each callback input type, but I'll program ergonomics first and performance later, if needs be. On the internal side the amount of events and crossbeam senders looks like it will be fairly clunky, but user facing should be hidden away.